### PR TITLE
SNOW-2205669 Exclude no-ide targets from the initial sync query

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -75,17 +75,19 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
       }
     }
 
+    String query = String.format("attr('tags', '^((?!no-ide).)*$', %s)", targets);
+
     if (allowManualTargetsSync) {
-      return targets.toString();
+      return query;
     }
 
     // exclude 'manual' targets, which shouldn't be built when expanding wildcard target patterns
     if (SystemInfo.isWindows) {
       // TODO(b/201974254): Windows support for Bazel sync (see
       // https://github.com/bazelbuild/intellij/issues/113).
-      return String.format("attr('tags', '^((?!manual).)*$', %s)", targets);
+      return String.format("attr('tags', '^((?!manual).)*$', %s)", query);
     }
-    return String.format("attr(\"tags\", \"^((?!manual).)*$\", %s)", targets);
+    return String.format("attr(\"tags\", \"^((?!manual).)*$\", %s)", query);
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
@@ -270,8 +270,9 @@ public class WildcardTargetExpander {
     if (targetList.isEmpty()) {
       return targetList;
     }
+    String query = String.format("attr('tags', '^((?!no-ide).)*$', %s)", targetList);
     return excludeManualTargets
-        ? String.format("attr('tags', '%s', %s)", MANUAL_EXCLUDE_TAG, targetList)
-        : targetList;
+        ? String.format("attr('tags', '%s', %s)", MANUAL_EXCLUDE_TAG, query)
+        : query;
   }
 }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/base/dependencies/BlazeQueryDirectoryToTargetProviderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/base/dependencies/BlazeQueryDirectoryToTargetProviderTest.java
@@ -54,7 +54,11 @@ public class BlazeQueryDirectoryToTargetProviderTest extends BlazeIntegrationTes
         true,
         workspacePathResolver);
 
+    String expQueryString = String.format(
+        "attr('tags', '^((?!no-ide).)*$', %s - %s)",
+        TargetExpression.allFromPackageRecursive(included),
+        TargetExpression.allFromPackageRecursive(excluded));
 
-    assertThat(queryString).isEqualTo(TargetExpression.allFromPackageRecursive(included) + " - " + TargetExpression.allFromPackageRecursive(excluded));
+    assertThat(queryString).isEqualTo(expQueryString);
   }
 }


### PR DESCRIPTION
This is to prevent targets that are not picked up by the aspect to influence the decision of sharding the sync.

This is the same as the query sync feature does already.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

